### PR TITLE
Handle a blocking/result response that is demoted to async.

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -45,7 +45,11 @@ class Actions extends Resources {
   invoke (options) {
     options = options || {}
     if (options.blocking && options.result) {
-      return super.invoke(options).then(result => result.response.result)
+      return super.invoke(options).then(result => {
+        if (result.response) {
+          return result.response.result
+        } else return Promise.reject(result)
+      })
     }
 
     return super.invoke(options)

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -246,6 +246,25 @@ test('should invoke action to retrieve result', t => {
   })
 })
 
+test('should invoke action to retrieve result but request is demoted to async', t => {
+  t.plan(4)
+  const ns = '_'
+  const client = {}
+  const actions = new Actions(client)
+  const result = { activationId: '123456' }
+
+  client.request = (method, path, options) => {
+    t.is(method, 'POST')
+    t.is(path, `namespaces/${ns}/actions/12345`)
+    t.deepEqual(options.qs, { blocking: true })
+    return Promise.resolve(result)
+  }
+
+  return actions.invoke({ name: '12345', result: true, blocking: true }).catch(_result => {
+    t.deepEqual(_result, result)
+  })
+})
+
 test('should invoke action to retrieve result without blocking', t => {
   t.plan(4)
   const ns = '_'


### PR DESCRIPTION
A blocking invoke that takes too long to complete may be demoted by the backend to an async invoke with the result being `{ activationId }` only. To preserve the behavior of the function, this patch will complete the promise with a `reject` should that happen.

Closes #199.