### PR TITLE
Allow clients to override the namespace for the api gateway APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,20 @@
 
 # Changelog
 
-## v3.19.0
+## v3.21.0
+
+* Allow clients to override API mappings for the Route operations (#201)
+* Handle a blocking/result response that is demoted to async (#199)
+* Fix handling of request exceptions in client.js (#196)
+* Allow update to action without requiring a code artifact (#195)
+
+## v3.20.0
+
+* Removed all references to Incubator now Apache OpenWhisk has passed incubation (#190, #192)
+* Add proxy agent to be included by runtime, rather than building in (#175)
+* Re-worked CI/CD setup (#180)
+
+## v3.19.0-incubating
 
 * Initial release as an Apache Incubator project.
 * Add support for using HTTP Proxy with library (#147)

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache OpenWhisk Client Js
-Copyright 2016-2019 The Apache Software Foundation
+Copyright 2016-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -23,8 +23,21 @@ const names = require('./names')
 const CREATE_PARAMS = ['relpath', 'operation', 'action']
 
 class Routes extends BaseOperation {
+  constructor (client, routeApiPathMapper) {
+    super(client)
+    if (typeof routeApiPathMapper === 'function') {
+      this.routeApiPathMapper = routeApiPathMapper
+    } else if (routeApiPathMapper) {
+      throw new Error('Illegal parameter, must be a function.')
+    }
+  }
+
   routeMgmtApiPath (path) {
-    return `web/whisk.system/apimgmt/${path}.http`
+    if (this.routeApiPathMapper) {
+      return this.routeApiPathMapper(path)
+    } else {
+      return `web/whisk.system/apimgmt/${path}`
+    }
   }
 
   get (options) {

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -244,7 +244,7 @@ test('delete routes providing basepath and name', t => {
 
 test('should create a route', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey }
   const client = { pathUrl, options: clientOptions }
@@ -260,7 +260,7 @@ test('should create a route', t => {
         name: 'helloAction',
         namespace: '_',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/_/default/helloAction.http',
         authkey: apiKey
       }
     }
@@ -278,7 +278,7 @@ test('should create a route', t => {
 
 test('should create a route from swagger file', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey }
   const client = { pathUrl, options: clientOptions }
@@ -302,7 +302,7 @@ test('should create a route from swagger file', t => {
 
 test('should create a route with api name', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey }
   const client = { pathUrl, options: clientOptions }
@@ -319,7 +319,7 @@ test('should create a route with api name', t => {
         name: 'helloAction',
         namespace: '_',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/_/default/helloAction.http',
         authkey: apiKey
       }
     }
@@ -337,7 +337,7 @@ test('should create a route with api name', t => {
 
 test('should create a route with apigwToken', t => {
   t.plan(4)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey, apigwToken: 'token', apigwSpaceGuid: 'space' }
   const client = { pathUrl, options: clientOptions }
@@ -353,7 +353,7 @@ test('should create a route with apigwToken', t => {
         name: 'helloAction',
         namespace: '_',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/_/default/helloAction.http',
         authkey: apiKey
       }
     }
@@ -372,7 +372,7 @@ test('should create a route with apigwToken', t => {
 
 test('should create a route with response type', t => {
   t.plan(4)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey }
   const client = { pathUrl, options: clientOptions }
@@ -388,7 +388,7 @@ test('should create a route with response type', t => {
         name: 'helloAction',
         namespace: '_',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/_/default/helloAction.http',
         authkey: apiKey
       }
     }
@@ -407,7 +407,7 @@ test('should create a route with response type', t => {
 
 test('should create a route with secure key', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const secureKey = 'some_key'
   const clientOptions = { apiKey }
@@ -424,7 +424,7 @@ test('should create a route with secure key', t => {
         name: 'helloAction',
         namespace: '_',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/_/default/helloAction.http',
         authkey: apiKey,
         secureKey: secureKey
       }
@@ -443,7 +443,7 @@ test('should create a route with secure key', t => {
 
 test('should create a route with apigwToken and action with package', t => {
   t.plan(4)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey, apigwToken: 'token', apigwSpaceGuid: 'space' }
   const client = { pathUrl, options: clientOptions }
@@ -459,7 +459,7 @@ test('should create a route with apigwToken and action with package', t => {
         name: 'package/helloAction',
         namespace: '_',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/package/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/_/package/helloAction.http',
         authkey: apiKey
       }
     }
@@ -478,7 +478,7 @@ test('should create a route with apigwToken and action with package', t => {
 
 test('should create a route with apigwToken and action with package & ns', t => {
   t.plan(4)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey, apigwToken: 'token', apigwSpaceGuid: 'space' }
   const client = { pathUrl, options: clientOptions }
@@ -494,7 +494,7 @@ test('should create a route with apigwToken and action with package & ns', t => 
         name: 'package/helloAction',
         namespace: 'ns',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/ns/package/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/ns/package/helloAction.http',
         authkey: apiKey
       }
     }
@@ -513,7 +513,7 @@ test('should create a route with apigwToken and action with package & ns', t => 
 
 test('should create a route using global ns', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey, namespace: 'global_ns' }
   const client = { pathUrl, options: clientOptions }
@@ -529,7 +529,7 @@ test('should create a route using global ns', t => {
         name: 'helloAction',
         namespace: 'global_ns',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/global_ns/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/global_ns/default/helloAction.http',
         authkey: apiKey
       }
     }
@@ -547,7 +547,7 @@ test('should create a route using global ns', t => {
 
 test('should create a route using basepath', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey }
   const client = { pathUrl, options: clientOptions }
@@ -563,7 +563,7 @@ test('should create a route using basepath', t => {
         name: 'helloAction',
         namespace: '_',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/_/default/helloAction.http',
         authkey: apiKey
       }
     }
@@ -581,7 +581,7 @@ test('should create a route using basepath', t => {
 
 test('should create a route using fully-qualified action name', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey }
   const client = { pathUrl, options: clientOptions }
@@ -597,7 +597,7 @@ test('should create a route using fully-qualified action name', t => {
         name: 'foo/helloAction',
         namespace: 'test',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/test/foo/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/test/foo/helloAction.http',
         authkey: apiKey
       }
     }
@@ -615,7 +615,7 @@ test('should create a route using fully-qualified action name', t => {
 
 test('should create a route using action name with ns', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey: apiKey }
   const client = { pathUrl, options: clientOptions }
@@ -631,7 +631,7 @@ test('should create a route using action name with ns', t => {
         name: 'helloAction',
         namespace: 'test',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/test/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/test/default/helloAction.http',
         authkey: apiKey
       }
     }
@@ -649,7 +649,7 @@ test('should create a route using action name with ns', t => {
 
 test('should create a route using action name with ns overriding defaults', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey, namespace: 'global' }
   const client = { pathUrl, options: clientOptions }
@@ -665,7 +665,7 @@ test('should create a route using action name with ns overriding defaults', t =>
         name: 'helloAction',
         namespace: 'test',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/test/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/test/default/helloAction.http',
         authkey: apiKey
       }
     }
@@ -683,7 +683,7 @@ test('should create a route using action name with ns overriding defaults', t =>
 
 test('should create a route with path parameters', t => {
   t.plan(3)
-  const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const pathUrl = path => `https://example.com/api/v1/${path}`
   const apiKey = 'username:password'
   const clientOptions = { apiKey }
   const client = { pathUrl, options: clientOptions }
@@ -699,7 +699,7 @@ test('should create a route with path parameters', t => {
         name: 'helloAction',
         namespace: '_',
         backendMethod: 'GET',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
+        backendUrl: 'https://example.com/api/v1/web/_/default/helloAction.http',
         authkey: apiKey
       },
       pathParameters: [

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -89,6 +89,20 @@ test('get routes with incorrect parameters', t => {
   t.throws(() => { routes.get({ basepath: 'id', name: 'id' }) }, /Invalid parameters: use basepath or name, not both/)
 })
 
+// OVERRIDE gateway package
+test('should override package name for apigateway', t => {
+  t.plan(3)
+  const client = { options: {} }
+  client.request = (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, routes.routeMgmtApiPath('getApi'))
+    t.is(path, 'foo/bar/baz/getApi')
+  }
+
+  const routes = new Routes(client, (p) => `foo/bar/baz/${p}`)
+  return routes.list()
+})
+
 // ADD NAME TO OTHER METHODS
 
 test('should list all routes', t => {


### PR DESCRIPTION
The Route class hard codes `whisk.system` as the namespace hosting the API gateway API. This change allows clients to override the base API path.

Closes https://github.com/apache/openwhisk-client-js/issues/202.