### PR TITLE
Add field 'rules' in Trigger interface

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -215,6 +215,12 @@ declare namespace openwhisk {
     interface Trigger extends TriggerDesc {
         parameters?: KeyVal[];
         limits?: any;
+        rules?: {
+            [key: string]: {
+                action: PathName;
+                status: Status;
+            }
+        }
     }
 
     interface Route {


### PR DESCRIPTION
Edit TS declaration file to get rules information via `ow.triggers.get()`.