### PR TITLE
Allow custom headers

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -161,12 +161,13 @@ class Client {
         json: true,
         method: method,
         url: this.pathUrl(path),
-        rejectUnauthorized: !this.options.ignoreCerts,
-        headers: {
-          'User-Agent': (options && options['User-Agent']) || process.env['__OW_USER_AGENT'] || 'openwhisk-client-js',
-          Authorization: header
-        }
+        rejectUnauthorized: !this.options.ignoreCerts
       }, options)
+
+      parms.headers = Object.assign({
+        'User-Agent': (options && options['User-Agent']) || process.env['__OW_USER_AGENT'] || 'openwhisk-client-js',
+        Authorization: header
+      }, parms.headers)
 
       if (this.options.cert && this.options.key) {
         parms.cert = this.options.cert

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -77,6 +77,22 @@ test('apihost and apiversion set', t => {
   t.is(client.options.apiVersion, 'v2')
 })
 
+test('option headers are respected', async t => {
+  const client = new Client({ api_key: 'username:password', apihost: 'blah' })
+  const METHOD = 'get'
+  const PATH = 'some/path/to/resource'
+  const OPTIONS = { headers: {
+    'x-custom-header': 'some-value',
+    'User-Agent': 'some-custom-useragent-string'
+  } }
+  const params = await client.params(METHOD, PATH, OPTIONS)
+  t.true(params.headers.hasOwnProperty('Authorization'))
+  t.true(params.headers.hasOwnProperty('x-custom-header'))
+  // options.headers overwrite defaults if they match
+  t.true(params.headers.hasOwnProperty('User-Agent'))
+  t.true(params.headers['User-Agent'] === OPTIONS.headers['User-Agent'])
+})
+
 test('should support deprecated explicit constructor options', t => {
   const client = new Client({
     namespace: 'ns',


### PR DESCRIPTION
headers were being overwritten if they were part of the options passed in.
This change uses Object.assign on the inner headers object so headers are only overwritten if they have the same key.