### PR TITLE
fix: relax Kind typings

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -256,20 +256,7 @@ declare namespace openwhisk {
         components: string[];
     }
 
-    type Kind =
-        "" |
-        "java" |
-        "nodejs:default" |
-        "nodejs:6" |
-        "nodejs:8" |
-        "python:default" |
-        "python:3" |
-        "python:2" |
-        "swift:default" |
-        "swift:3.1.1" |
-        "swift:4.1" |
-        "php:default" |
-        "php:7.1";
+    type Kind = string;
 
     interface Limits {
         timeout?: number;


### PR DESCRIPTION
This PR relaxes the Kind type from a hard-coded (and way out-of-date) type disjunction into a plain string type... rather than trying to keep this module in sync with ... upstream openwhisk but also with whatever manifest a particular provider may have imposed

Fixes #214