### PR TITLE
Adding missing properties to Exec TS defs

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -250,6 +250,7 @@ declare namespace openwhisk {
         code: string;
         binary?: boolean;
         main?: string;
+        image?: string;
     }
 
     interface Sequence {

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -248,7 +248,8 @@ declare namespace openwhisk {
     interface Exec {
         kind: Kind;
         code: string;
-        binary?: boolean
+        binary?: boolean;
+        main?: string;
     }
 
     interface Sequence {


### PR DESCRIPTION
Should include `image` property for docker-based actions.