### PR TITLE
Update deprecated url lib

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,6 @@
 const messages = require('./messages')
 const OpenWhiskError = require('./openwhisk_error')
 const needle = require('needle')
-const url = require('url')
 const http = require('http')
 const retry = require('async-retry')
 
@@ -229,15 +228,12 @@ class Client {
   }
 
   pathUrl (urlPath) {
-    const endpoint = this.apiUrl()
-    endpoint.pathname = url.resolve(endpoint.pathname, urlPath)
-    return url.format(endpoint)
+    return new URL(urlPath, this.apiUrl()).href
   }
 
   apiUrl () {
-    return url.parse(
-      this.options.api.endsWith('/') ? this.options.api : this.options.api + '/'
-    )
+    const api = this.options.api.endsWith('/') ? this.options.api : this.options.api + '/'
+    return new URL(api)
   }
 
   authHeader () {

--- a/test/unit/namespaces.test.js
+++ b/test/unit/namespaces.test.js
@@ -55,7 +55,7 @@ test('should list all namespaces, NOT passing through user-agent header (variant
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({ api: 'aaa', api_key: 'aaa' }).params(method, path, options)
+    const parms = await new Client({ api: 'http://aaa', api_key: 'aaa' }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
   }
 
@@ -71,7 +71,7 @@ test('should list all namespaces, NOT passing through user-agent header (variant
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({ api: 'aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
+    const parms = await new Client({ api: 'http://aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
   }
 
@@ -86,7 +86,7 @@ test('should list all namespaces, NOT passing through user-agent header (variant
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({ api: 'aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
+    const parms = await new Client({ api: 'http://aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
   }
 
@@ -115,7 +115,7 @@ test('should list all namespaces, using __OW_USER_AGENT', t => {
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({ api: 'aaa', api_key: 'aaa' }).params(method, path, options)
+    const parms = await new Client({ api: 'http://aaa', api_key: 'aaa' }).params(method, path, options)
     t.is(parms.headers['User-Agent'], 'my-useragent')
     delete process.env['__OW_USER_AGENT']
   }
@@ -132,7 +132,7 @@ test('should list all namespaces, NOT using __OW_USER_AGENT when noUserAgent tru
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({ api: 'aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
+    const parms = await new Client({ api: 'http://aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
     delete process.env['__OW_USER_AGENT']
   }
@@ -150,7 +150,7 @@ test('should list all namespaces, NOT using __OW_USER_AGENT when user-agent is p
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({ api: 'aaa', api_key: 'aaa' }).params(method, path, options)
+    const parms = await new Client({ api: 'http://aaa', api_key: 'aaa' }).params(method, path, options)
     t.is(parms.headers['User-Agent'], userAgent)
     delete process.env['__OW_USER_AGENT']
   }
@@ -168,7 +168,7 @@ test('should list all namespaces, NOT using __OW_USER_AGENT or user-agent when n
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({ api: 'aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
+    const parms = await new Client({ api: 'http://aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
     delete process.env['__OW_USER_AGENT']
   }


### PR DESCRIPTION
The `url` module is deprecated and causes the following warning when run: 
```[DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.```

This change updates it to use the WHATWG URL API instead, as well as modifying the unit tests to account for WHATWG's increased URL structure parsing.